### PR TITLE
chap.6 realm-2.0対応

### DIFF
--- a/app/src/main/java/jp/techacademy/yusuke/iwaki/ta_lesson6/MainActivity.java
+++ b/app/src/main/java/jp/techacademy/yusuke/iwaki/ta_lesson6/MainActivity.java
@@ -26,7 +26,7 @@ public class MainActivity extends AppCompatActivity {
     private RealmResults<Task> mTaskRealmResults;
     private RealmChangeListener mRealmListener = new RealmChangeListener() {
         @Override
-        public void onChange() {
+        public void onChange(Object element) {
             reloadListView();
         }
     };

--- a/app/src/main/java/jp/techacademy/yusuke/iwaki/ta_lesson6/MainActivity.java
+++ b/app/src/main/java/jp/techacademy/yusuke/iwaki/ta_lesson6/MainActivity.java
@@ -91,7 +91,7 @@ public class MainActivity extends AppCompatActivity {
                         RealmResults<Task> results = mRealm.where(Task.class).equalTo("id", task.getId()).findAll();
 
                         mRealm.beginTransaction();
-                        results.clear();
+                        results.deleteAllFromRealm();
                         mRealm.commitTransaction();
 
                         reloadListView();
@@ -114,6 +114,8 @@ public class MainActivity extends AppCompatActivity {
         ArrayList<Task> taskArrayList = new ArrayList<>();
 
         for (int i = 0; i < mTaskRealmResults.size(); i++) {
+            if (!mTaskRealmResults.get(i).isValid()) continue;
+
             Task task = new Task();
 
             task.setId(mTaskRealmResults.get(i).getId());

--- a/app/src/main/java/jp/techacademy/yusuke/iwaki/ta_lesson6/TaskApp.java
+++ b/app/src/main/java/jp/techacademy/yusuke/iwaki/ta_lesson6/TaskApp.java
@@ -3,13 +3,11 @@ package jp.techacademy.yusuke.iwaki.ta_lesson6;
 import android.app.Application;
 
 import io.realm.Realm;
-import io.realm.RealmConfiguration;
 
 public class TaskApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        RealmConfiguration realmConfiguration = new RealmConfiguration.Builder(this).build();
-        Realm.setDefaultConfiguration(realmConfiguration);
+        Realm.init(this);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-        classpath "io.realm:realm-gradle-plugin:0.88.2"
+        classpath "io.realm:realm-gradle-plugin:2.0.2"
     }
 }
 


### PR DESCRIPTION
#1 に加えて、
- Realmの clearメソッドは0.89くらいでDeprecated（呼ぶと強制終了する）になってしまったので、deleteAllFromRealmに呼び替える必要があります
- 0.89から、[RealmResultsは必ずしもライブアップデートされなくなった](https://github.com/realm/realm-java/issues/875#issuecomment-239137759) らしいので、生存確認処理を入れる必要があります
